### PR TITLE
fix: improve slow rendering performance

### DIFF
--- a/components/Charts.tsx
+++ b/components/Charts.tsx
@@ -26,11 +26,10 @@ const Charts: React.FC<{ year: Year }> = ({ year }) => {
     <div ref={ref} cx="wrapper">
       {/* Chart 1: Eligible vs Offers */}
       <motion.div
+        animate={{ opacity: 1, y: 0 }}
         cx="chart-box"
-        initial={{ opacity: 0, y: 20 }}
+        initial={false}
         transition={{ duration: 0.5, ease: 'easeOut' }}
-        viewport={{ once: true, amount: 0.15 }}
-        whileInView={{ opacity: 1, y: 0 }}
       >
         <h3 cx="chart-title">Eligible Students & Placement Offers</h3>
         <div cx="chart-container">
@@ -94,11 +93,10 @@ const Charts: React.FC<{ year: Year }> = ({ year }) => {
 
       {/* Chart 2: Branch-wise Placement Percentage */}
       <motion.div
+        animate={{ opacity: 1, y: 0 }}
         cx="chart-box"
-        initial={{ opacity: 0, y: 20 }}
+        initial={false}
         transition={{ duration: 0.5, delay: 0.1, ease: 'easeOut' }}
-        viewport={{ once: true, amount: 0.15 }}
-        whileInView={{ opacity: 1, y: 0 }}
       >
         <h3 cx="chart-title">Branch-wise Placement Percentage</h3>
         <div cx="chart-container">

--- a/components/FAQs.tsx
+++ b/components/FAQs.tsx
@@ -30,11 +30,10 @@ const FAQs: React.FC = () => {
       <div cx="ctr">
         {/* Section Header */}
         <motion.div
+          animate={{ opacity: 1, y: 0 }}
           cx="title-wrapper"
-          initial={{ opacity: 0, y: -15 }}
+          initial={false}
           transition={{ duration: 0.5 }}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={{ opacity: 1, y: 0 }}
         >
           <h2 cx="title">
             Frequently Asked <span cx="highlight">Questions</span>
@@ -48,11 +47,10 @@ const FAQs: React.FC = () => {
 
         {/* Compact Row Cards Grid */}
         <motion.div
+          animate="visible"
           cx="grid-container"
-          initial="hidden"
+          initial={false}
           variants={containerVariants}
-          viewport={{ once: true, amount: 0.2 }}
-          whileInView="visible"
         >
           {questions.map(({ question: q, answer: a }) => (
             <button

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -50,12 +50,7 @@ const Hero: React.FC = () => {
       <div cx="grid-overlay" />
 
       <div cx="ctr">
-        <motion.div
-          animate="visible"
-          cx="grid-layout"
-          initial="hidden"
-          variants={containerVariants}
-        >
+        <motion.div animate="visible" cx="grid-layout" initial={false} variants={containerVariants}>
           {/* Left Column: Typography & Action Buttons */}
           <div cx="left-col">
             <motion.h1 cx="lead" variants={itemVariants}>

--- a/components/OurEsteemedRecruiters.tsx
+++ b/components/OurEsteemedRecruiters.tsx
@@ -45,13 +45,7 @@ const OurEsteemedRecruiters: React.FC = () => {
     <section cx="sect" id="our-esteemed-recruiters">
       <div cx="ctr">
         {/* Section Header */}
-        <motion.div
-          cx="title-wrapper"
-          initial="hidden"
-          variants={titleVariants}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView="visible"
-        >
+        <motion.div animate="visible" cx="title-wrapper" initial={false} variants={titleVariants}>
           <h2 cx="title">
             Our Esteemed <span cx="highlight">Recruiters</span>
           </h2>
@@ -63,13 +57,7 @@ const OurEsteemedRecruiters: React.FC = () => {
         </motion.div>
 
         {/* Logo Grid Section with Entrance Stagger Animation */}
-        <motion.div
-          cx="logo-grid"
-          initial="hidden"
-          variants={containerVariants}
-          viewport={{ once: true, amount: 0.1 }}
-          whileInView="visible"
-        >
+        <motion.div animate="visible" cx="logo-grid" initial={false} variants={containerVariants}>
           {allCompanies.map(([name, src]) => (
             <motion.div
               key={cyrb53(`recruiter-card-${name}`)}

--- a/components/Policy.tsx
+++ b/components/Policy.tsx
@@ -27,13 +27,7 @@ const Policy: React.FC = () => {
         </div>
 
         {/* Centralized Policy Container */}
-        <motion.div
-          cx="policy-card"
-          initial="hidden"
-          variants={containerVariants}
-          viewport={{ once: true, amount: 0.2 }}
-          whileInView="visible"
-        >
+        <motion.div animate="visible" cx="policy-card" initial={false} variants={containerVariants}>
           {/* Main Introduction Text */}
           <p cx="intro-text">
             The placement season in IIIT Kota runs throughout the year, commencing tentatively from

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -6,11 +6,10 @@ const Stats: React.FC = () => (
   <section cx="sect" id="statistics">
     <div cx="ctr">
       <motion.div
+        animate={{ opacity: 1, y: 0 }}
         cx="title-wrapper"
-        initial={{ opacity: 0, y: -15 }}
+        initial={false}
         transition={{ duration: 0.5 }}
-        viewport={{ once: true, amount: 0.5 }}
-        whileInView={{ opacity: 1, y: 0 }}
       >
         <h2 cx="title">
           Placement <span cx="highlight">Statistics</span>

--- a/components/WhyRecruit.tsx
+++ b/components/WhyRecruit.tsx
@@ -89,11 +89,10 @@ const WhyRecruit: React.FC = () => {
       <div cx="ctr">
         {/* Centered Header Title Block */}
         <motion.div
+          animate={{ opacity: 1, y: 0 }}
           cx="title-wrapper"
-          initial={{ opacity: 0, y: -15 }}
+          initial={false}
           transition={{ duration: 0.5 }}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={{ opacity: 1, y: 0 }}
         >
           <h2 cx="title">
             Why Recruit <span cx="highlight">IIIT Kota?</span>
@@ -122,11 +121,10 @@ const WhyRecruit: React.FC = () => {
 
           {/* Cards Viewport Mask Container */}
           <motion.div
+            animate="show"
             cx="slider-container"
-            initial="hidden"
+            initial={false}
             variants={containerVariants}
-            viewport={{ once: true, amount: 0.15 }}
-            whileInView="show"
           >
             <div
               cx="slider-track"


### PR DESCRIPTION
### Description
This PR addresses the frontend bottlenecks causing delayed component rendering ("pop-in" lag) upon page mount and navigation.

During initial page load, the browser rendered only the static `Navbar` immediately, leaving the rest of the screen (the `Hero` and other sections) blank at `opacity: 0` for 3 to 5 seconds until client-side hydration completed. 

### Key Changes
1. **Fixed Hero Component SSR Block ([Hero.tsx](file:///d:/tnp-iiit-kota/components/Hero.tsx)):**
   - Changed `initial="hidden"` to `initial={false}` on the parent `motion.div` grid wrapper. 
   - This ensures that the Hero section renders completely visible in the raw server-rendered HTML rather than waiting for client-side JavaScript hydration to fade it in.

2. **Removed Viewport Scroll-Trigger Blocks:**
   - Replaced Framer Motion's `whileInView` and `viewport` props with standard mount animations (`animate` and `initial={false}`) to prevent core sections from staying hidden or popping in late during navigation.
   - Modified files:
     - [Charts.tsx](file:///d:/tnp-iiit-kota/components/Charts.tsx)
     - [FAQs.tsx](file:///d:/tnp-iiit-kota/components/FAQs.tsx)
     - [OurEsteemedRecruiters.tsx](file:///d:/tnp-iiit-kota/components/OurEsteemedRecruiters.tsx)
     - [Policy.tsx](file:///d:/tnp-iiit-kota/components/Policy.tsx)
     - [Stats.tsx](file:///d:/tnp-iiit-kota/components/Stats.tsx)
     - [WhyRecruit.tsx](file:///d:/tnp-iiit-kota/components/WhyRecruit.tsx)

### Impact
- **Instant FCP (First Contentful Paint):** The home screen and inner sections render immediately when a user visits or navigates.
- **No Hydration Delay:** The page no longer waits for client-side JavaScript/Framer Motion to boot up before showing critical structural content.